### PR TITLE
Prevent trailing commas from being part of a name

### DIFF
--- a/lib/nameable/latin.rb
+++ b/lib/nameable/latin.rb
@@ -118,7 +118,7 @@ module Nameable
       raise InvalidNameError unless name
       if name.class == String
         if name.index(',')
-          name = "#{$2} #{$1}" if name =~ /^([a-z]+)\s*,\s*,*(.*)/i
+          name = "#{$2} #{$1}" if name =~ /^([a-z]+)\s*,\s*,*([^,]*)/i
         end
 
         name = name.strip.split(/\s+/)

--- a/spec/nameable/latin_spec.rb
+++ b/spec/nameable/latin_spec.rb
@@ -64,6 +64,44 @@ describe Nameable::Latin do
     end
   end
 
+  context('last_name, first_name') do
+    subject(:n) { Nameable::Latin.new.parse("Horn, Chris") }
+    it '.prefix' do
+      expect(n.prefix).to be_nil
+    end
+    it '.first' do
+      expect(n.first).to eq('Chris')
+    end
+    it '.middle' do
+      expect(n.middle).to be_nil
+    end
+    it '.last' do
+      expect(n.last).to eq('Horn')
+    end
+    it '.suffix' do
+      expect(n.suffix).to be_nil
+    end
+  end
+
+  context('last_name, first_name,') do
+    subject(:n) { Nameable::Latin.new.parse("Horn, Chris,") }
+    it '.prefix' do
+      expect(n.prefix).to be_nil
+    end
+    it '.first' do
+      expect(n.first).to eq('Chris')
+    end
+    it '.middle' do
+      expect(n.middle).to be_nil
+    end
+    it '.last' do
+      expect(n.last).to eq('Horn')
+    end
+    it '.suffix' do
+      expect(n.suffix).to be_nil
+    end
+  end
+
   context('with a simple middle name') do
     subject(:n) { Nameable::Latin.new.parse("Chris Derp Horn") }
     it '.prefix' do


### PR DESCRIPTION
This was an easy fix that I should have done a long time ago. :/

I added a test for this, and for a simple case of a comma separated
name.