### PR TITLE
Additional prefixes patterns 

### DIFF
--- a/lib/nameable/latin/patterns.rb
+++ b/lib/nameable/latin/patterns.rb
@@ -4,6 +4,14 @@ module Nameable
     # Regex's to match the detritus that people add to their names
     module Patterns
       PREFIX = {
+        "Capt."  => /^\(*(capt\.*|captain)\)*$/i,
+        "Dame"   => /^\(*(dame)\)*$/i,
+        "Dr."    => /^\(*(dr\.*|doctor)\)*$/i,
+        "Fr."    => /^\(*(fr\.*|friar)\)*$/i,
+        "Hon."	 => /^\(*(hon\.*|honorable)\)*$/i,
+        "Imam"   => /^\(*(imam)\)*$/i,
+        "Ofc."   => /^\(*(ofc\.*|officer)\)*$/i,
+        "Master" => /^\(*(master)\)*$/i,
         "Mr."    => /^\(*(mr\.*|mister)\)*$/i,
         "Mrs."   => /^\(*(mrs\.*|misses)\)*$/i,
         "Ms."    => /^\(*(ms\.*|miss)\)*$/i,
@@ -11,6 +19,7 @@ module Nameable
         "Rev."   => /^\(*(rev\.*|reverend)\)*$/i,
         "Fr."    => /^\(*(fr\.*|friar)\)*$/i,
         "Master" => /^\(*(master)\)*$/i,
+        "Rabbi"  => /^\(*(rabbi)\)*$/i,
         "Sir"    => /^\(*(sir)\)*$/i
       }
 

--- a/lib/nameable/latin/patterns.rb
+++ b/lib/nameable/latin/patterns.rb
@@ -7,7 +7,7 @@ module Nameable
         "Capt."  => /^\(*(capt\.*|captain)\)*$/i,
         "Dame"   => /^\(*(dame)\)*$/i,
         "Dr."    => /^\(*(dr\.*|doctor)\)*$/i,
-        "Fr."    => /^\(*(fr\.*|friar)\)*$/i,
+        "Fr."    => /^\(*(fr\.*|friar|father)\)*$/i,
         "Hon."	 => /^\(*(hon\.*|honorable)\)*$/i,
         "Imam"   => /^\(*(imam)\)*$/i,
         "Ofc."   => /^\(*(ofc\.*|officer)\)*$/i,
@@ -17,7 +17,6 @@ module Nameable
         "Ms."    => /^\(*(ms\.*|miss)\)*$/i,
         "Dr."    => /^\(*(dr\.*|doctor)\)*$/i,
         "Rev."   => /^\(*(rev\.*|reverend)\)*$/i,
-        "Fr."    => /^\(*(fr\.*|friar)\)*$/i,
         "Master" => /^\(*(master)\)*$/i,
         "Rabbi"  => /^\(*(rabbi)\)*$/i,
         "Sir"    => /^\(*(sir)\)*$/i

--- a/spec/nameable/latin_spec.rb
+++ b/spec/nameable/latin_spec.rb
@@ -190,7 +190,7 @@ describe Nameable::Latin do
       end
     end
 
-    %w{Fr Fr. Friar}.each do |prefix|
+    %w{Fr Fr. Friar Father}.each do |prefix|
       it prefix do
         expect(Nameable::Latin.new.parse("#{prefix} Chris Horn").prefix).to eq('Fr.')
       end

--- a/spec/nameable/latin_spec.rb
+++ b/spec/nameable/latin_spec.rb
@@ -196,12 +196,29 @@ describe Nameable::Latin do
       end
     end
 
-    %w{Master Sir}.each do |prefix|
+    %w{Dame Rabbi Imam Master Sir}.each do |prefix|
       it prefix do
         expect(Nameable::Latin.new.parse("#{prefix} Chris Horn").prefix).to eq(prefix)
       end
     end
 
+    %w{Hon Hon. Honorable}.each do |prefix|
+      it prefix do
+        expect(Nameable::Latin.new.parse("#{prefix} Chris Horn").prefix).to eq('Hon.')
+      end
+    end
+
+    %w{Capt Capt. Captain}.each do |prefix|
+      it prefix do
+        expect(Nameable::Latin.new.parse("#{prefix} Chris Horn").prefix).to eq('Capt.')
+      end
+    end
+
+    %w{Ofc Ofc. Officer}.each do |prefix|
+      it prefix do
+        expect(Nameable::Latin.new.parse("#{prefix} Chris Horn").prefix).to eq('Ofc.')
+      end
+    end
   end
 
   context('suffix patterns (formatted)') do


### PR DESCRIPTION
Rebased version of #5. 

Note that original CI failure was due to Ruby 1.9 issue on Travis. 